### PR TITLE
reproduce DeepSHM results

### DIFF
--- a/deepshm/README.md
+++ b/deepshm/README.md
@@ -1,0 +1,26 @@
+## DeepSHM
+
+This directory contains data and script to reproduce the DeepSHM performance metrics in the manuscript.
+
+The DeepSHM outputs on the `val_curatedShmoofNotbigNoN` data is `deepshm_predictions.csv.gz`.
+The CSV file has the following columns:
+|column name | description|
+|---|---|
+| `pcp_index` | index of the parent-child pair in `val_curatedShmoofNotbigNoN` |
+| `branch_length` | number of mutations divided by sequence length |
+| `site` | nucleotide site |
+| `mutability` | DeepSHM mutation frequency |
+| `A` | DeepSHM conditional substitution probability to A |
+| `C` | DeepSHM conditional substitution probability to C |
+| `G` | DeepSHM conditional substitution probability to G |
+| `T` | DeepSHM conditional substitution probability to T |
+| `mutation` | if a mutation occur at the site in the parent-child pair, indicates the resulting nucleotide; otherwise, `-` |
+
+Each row in the CSV file corresponds to a site in a parent-child pair.
+Note that for sites at the edge of the sequence, which cannot be the center of a 15-mer, the result is taken from the average of all possible combinations of nucleotides for the out-of-bounds positions in the 15-mer.
+
+Run the script
+
+    python deepshm_eval.py
+
+to compute substitution accuracy, AUROC, AUPRC, and R-precision.

--- a/deepshm/deepshm_eval.py
+++ b/deepshm/deepshm_eval.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score, average_precision_score
+
+df = pd.read_csv("deepshm_predictions.csv.gz")
+
+mutabilities = df['mutability'].to_numpy()
+branch_lengths = df['branch_length'].to_numpy()
+scaled_muts = mutabilities * branch_lengths
+true_muts = [0 if x == '-' else 1 for x in df['mutation']]
+
+auroc = roc_auc_score(true_muts, scaled_muts)
+auprc = average_precision_score(true_muts, scaled_muts)
+
+
+subs_df = df[df['mutation']!='-']
+ncorr=0
+for i,row in subs_df.iterrows():
+    nt = row['mutation']
+    if np.argmax(row[list('ACGT')]) == 'ACGT'.index(nt):
+        ncorr += 1
+sub_acc = ncorr/subs_df.shape[0]
+
+
+g = df.groupby('pcp_index')
+pcp_rprec = []
+for ipcp in g.groups.keys():
+    pcp_df = g.get_group(ipcp).sort_values('mutability', ascending=False)
+    nmuts = pcp_df[pcp_df['mutation']!='-'].shape[0]
+    top_df = pcp_df.head(nmuts)
+    nmatches = top_df[top_df['mutation']!='-'].shape[0]
+    pcp_rprec.append(nmatches/nmuts)
+    
+rprec = np.mean(pcp_rprec)    
+
+
+print('substitution accuracy:', sub_acc)
+print('AUROC:', auroc)
+print('AUPRC:', auprc)
+print('R-precision:', rprec)


### PR DESCRIPTION
I discovered that the DeepSHM results in the submission was done with scaling by number of mutations rather than mutation fraction as branch length. This is corrected in this PR. This only impacts AUROC and AUPRC.

Previous:

- `AUROC: 0.784`
- `AUPRC: 0.0865`

Now:
- `AUROC: 0.786`
- `AUPRC: 0.0876`